### PR TITLE
Fix mqtt procotol PUBLISH QoS 2 message error

### DIFF
--- a/src/sp/protocol/mqtt/mqtt_client.c
+++ b/src/sp/protocol/mqtt/mqtt_client.c
@@ -663,7 +663,6 @@ mqtt_recv_cb(void *arg)
 		// nni_mqtt_msg_encode(msg);
 		// nni_aio_set_msg(&work->send_aio, msg);
 		// nni_pipe_send(p->pipe, &work->send_aio);
-		nni_id_remove(&p->send_unack, packet_id);
 		work->state = WORK_PUBCOMP;
 		break;
 


### PR DESCRIPTION
The error was caused by removing the unacknowledged message when
receiving a PUBREC, should defer the removal to PUBCOMP received.