### PR TITLE
Fix dup invalid content before encoding & run test failed on Windows

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1283,15 +1283,8 @@ NNG_DECL int nng_pipe_getopt_string(nng_pipe, const char *, char **);
 // a library; it will affect all sockets.
 NNG_DECL void nng_closeall(void);
 
-
-#ifdef __MSC_VER
-#pragma pack(push, 1)
-#endif 
-typedef enum
-#if  defined(__MINGW32__) || defined(__MINGW64__)
-    __attribute__((__packed__))
-#endif
-{ NNG_MQTT_CONNECT           = 0x01,
+typedef enum {
+	NNG_MQTT_CONNECT     = 0x01,
 	NNG_MQTT_CONNACK     = 0x02,
 	NNG_MQTT_PUBLISH     = 0x03,
 	NNG_MQTT_PUBACK      = 0x04,
@@ -1305,11 +1298,8 @@ typedef enum
 	NNG_MQTT_PINGREQ     = 0x0C,
 	NNG_MQTT_PINGRESP    = 0x0D,
 	NNG_MQTT_DISCONNECT  = 0x0E,
-	NNG_MQTT_AUTH        = 0x0F } 
-	nng_mqtt_packet_type;
-#ifdef __MSC_VER
-#pragma pack(pop)
-#endif
+	NNG_MQTT_AUTH        = 0x0F
+} nng_mqtt_packet_type;
 
 struct mqtt_buf_t {
 	uint32_t length;

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1283,8 +1283,15 @@ NNG_DECL int nng_pipe_getopt_string(nng_pipe, const char *, char **);
 // a library; it will affect all sockets.
 NNG_DECL void nng_closeall(void);
 
-typedef enum {
-	NNG_MQTT_CONNECT     = 0x01,
+
+#ifdef __MSC_VER
+#pragma pack(push, 1)
+#endif 
+typedef enum
+#if  defined(__MINGW32__) || defined(__MINGW64__)
+    __attribute__((__packed__))
+#endif
+{ NNG_MQTT_CONNECT           = 0x01,
 	NNG_MQTT_CONNACK     = 0x02,
 	NNG_MQTT_PUBLISH     = 0x03,
 	NNG_MQTT_PUBACK      = 0x04,
@@ -1298,8 +1305,11 @@ typedef enum {
 	NNG_MQTT_PINGREQ     = 0x0C,
 	NNG_MQTT_PINGRESP    = 0x0D,
 	NNG_MQTT_DISCONNECT  = 0x0E,
-	NNG_MQTT_AUTH        = 0x0F
-} nng_mqtt_packet_type;
+	NNG_MQTT_AUTH        = 0x0F } 
+	nng_mqtt_packet_type;
+#ifdef __MSC_VER
+#pragma pack(pop)
+#endif
 
 struct mqtt_buf_t {
 	uint32_t length;

--- a/src/mqtt/mqtt.c
+++ b/src/mqtt/mqtt.c
@@ -170,6 +170,7 @@ nni_mqtt_msg_set_publish_topic(nni_msg *msg, const char *topic)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->var_header.publish.topic_name,
 	    (uint8_t *) topic, (uint32_t) strlen(topic));
+	proto_data->is_copied = true;
 }
 
 const char *
@@ -186,6 +187,7 @@ nni_mqtt_msg_set_publish_payload(nni_msg *msg, uint8_t *payload, uint32_t len)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(
 	    &proto_data->payload.publish.payload, payload, (uint32_t) len);
+	proto_data->is_copied = true;
 }
 
 uint8_t *
@@ -295,6 +297,7 @@ nni_mqtt_msg_set_subscribe_topics(
 		    proto_data->payload.subscribe.topic_arr, i,
 		    (const char *) topics[i].topic.buf, topics[i].qos);
 	}
+	proto_data->is_copied = true;
 }
 
 nni_mqtt_topic_qos *
@@ -328,6 +331,7 @@ nni_mqtt_msg_set_suback_return_codes(
 	memcpy(proto_data->payload.suback.ret_code_arr, ret_codes,
 	    ret_codes_count);
 	proto_data->payload.suback.ret_code_count = ret_codes_count;
+	proto_data->is_copied                     = true;
 }
 
 uint8_t *
@@ -367,6 +371,7 @@ nni_mqtt_msg_set_unsubscribe_topics(
 		    proto_data->payload.unsubscribe.topic_arr, i,
 		    (const char *) topics[i].buf);
 	}
+	proto_data->is_copied = true;
 }
 
 nni_mqtt_topic *
@@ -454,6 +459,7 @@ nni_mqtt_msg_set_connect_client_id(nni_msg *msg, const char *client_id)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.client_id,
 	    (const uint8_t *) client_id, (uint32_t) strlen(client_id));
+	proto_data->is_copied = true;
 }
 
 void
@@ -462,6 +468,7 @@ nni_mqtt_msg_set_connect_will_topic(nni_msg *msg, const char *will_topic)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.will_topic,
 	    (const uint8_t *) will_topic, (uint32_t) strlen(will_topic));
+	proto_data->is_copied = true;
 }
 
 void
@@ -470,6 +477,7 @@ nni_mqtt_msg_set_connect_will_msg(nni_msg *msg, const char *will_msg)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.will_msg,
 	    (const uint8_t *) will_msg, (uint32_t) strlen(will_msg));
+	proto_data->is_copied = true;
 }
 
 void
@@ -478,6 +486,7 @@ nni_mqtt_msg_set_connect_user_name(nni_msg *msg, const char *user_name)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.user_name,
 	    (const uint8_t *) user_name, (uint32_t) strlen(user_name));
+	proto_data->is_copied = true;
 }
 
 void
@@ -486,6 +495,7 @@ nni_mqtt_msg_set_connect_password(nni_msg *msg, const char *password)
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.password,
 	    (const uint8_t *) password, (uint32_t) strlen(password));
+	proto_data->is_copied = true;
 }
 
 const char *

--- a/src/mqtt/mqtt.c
+++ b/src/mqtt/mqtt.c
@@ -9,7 +9,6 @@ static nni_proto_msg_ops proto_msg_ops = {
 	.msg_dup = nni_mqtt_msg_dup
 };
 
-
 int
 nni_mqtt_msg_proto_data_alloc(nni_msg *msg)
 {
@@ -170,7 +169,7 @@ nni_mqtt_msg_set_publish_topic(nni_msg *msg, const char *topic)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->var_header.publish.topic_name,
-	    (uint8_t *) topic, strlen(topic));
+	    (uint8_t *) topic, (uint32_t) strlen(topic));
 }
 
 const char *
@@ -185,7 +184,8 @@ void
 nni_mqtt_msg_set_publish_payload(nni_msg *msg, uint8_t *payload, uint32_t len)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
-	mqtt_buf_create(&proto_data->payload.publish.payload, payload, len);
+	mqtt_buf_create(
+	    &proto_data->payload.publish.payload, payload, (uint32_t) len);
 }
 
 uint8_t *
@@ -453,7 +453,7 @@ nni_mqtt_msg_set_connect_client_id(nni_msg *msg, const char *client_id)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.client_id,
-	    (const uint8_t *) client_id, strlen(client_id));
+	    (const uint8_t *) client_id, (uint32_t) strlen(client_id));
 }
 
 void
@@ -461,7 +461,7 @@ nni_mqtt_msg_set_connect_will_topic(nni_msg *msg, const char *will_topic)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.will_topic,
-	    (const uint8_t *) will_topic, strlen(will_topic));
+	    (const uint8_t *) will_topic, (uint32_t) strlen(will_topic));
 }
 
 void
@@ -469,7 +469,7 @@ nni_mqtt_msg_set_connect_will_msg(nni_msg *msg, const char *will_msg)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.will_msg,
-	    (const uint8_t *) will_msg, strlen(will_msg));
+	    (const uint8_t *) will_msg, (uint32_t) strlen(will_msg));
 }
 
 void
@@ -477,7 +477,7 @@ nni_mqtt_msg_set_connect_user_name(nni_msg *msg, const char *user_name)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.user_name,
-	    (const uint8_t *) user_name, strlen(user_name));
+	    (const uint8_t *) user_name, (uint32_t) strlen(user_name));
 }
 
 void
@@ -485,7 +485,7 @@ nni_mqtt_msg_set_connect_password(nni_msg *msg, const char *password)
 {
 	nni_mqtt_proto_data *proto_data = nni_msg_get_proto_data(msg);
 	mqtt_buf_create(&proto_data->payload.connect.password,
-	    (const uint8_t *) password, strlen(password));
+	    (const uint8_t *) password, (uint32_t) strlen(password));
 }
 
 const char *
@@ -586,7 +586,7 @@ nni_mqtt_topic_array_set(
     nni_mqtt_topic *topic, size_t index, const char *topic_name)
 {
 	topic[index].buf    = (uint8_t *) nni_strdup(topic_name);
-	topic[index].length = strlen(topic_name);
+	topic[index].length = (uint32_t) strlen(topic_name);
 }
 
 void
@@ -612,7 +612,7 @@ nni_mqtt_topic_qos_array_set(nni_mqtt_topic_qos *topic_qos, size_t index,
     const char *topic_name, uint8_t qos)
 {
 	topic_qos[index].topic.buf    = (uint8_t *) nni_strdup(topic_name);
-	topic_qos[index].topic.length = strlen(topic_name);
+	topic_qos[index].topic.length = (uint32_t) strlen(topic_name);
 	topic_qos[index].qos          = qos;
 }
 

--- a/src/mqtt/mqtt.h
+++ b/src/mqtt/mqtt.h
@@ -187,18 +187,18 @@ union mqtt_payload {
 };
 
 typedef struct {
-	uint8_t              bit_0 : 1;
-	uint8_t              bit_1 : 1;
-	uint8_t              bit_2 : 1;
-	uint8_t              bit_3 : 1;
-	nni_mqtt_packet_type packet_type : 4;
+	uint8_t bit_0 : 1;
+	uint8_t bit_1 : 1;
+	uint8_t bit_2 : 1;
+	uint8_t bit_3 : 1;
+	uint8_t packet_type : 4;
 } mqtt_common_hdr;
 
 typedef struct {
-	uint8_t              retain : 1;
-	uint8_t              qos : 2;
-	uint8_t              dup : 1;
-	nni_mqtt_packet_type packet_type : 4;
+	uint8_t retain : 1;
+	uint8_t qos : 2;
+	uint8_t dup : 1;
+	uint8_t packet_type : 4;
 } mqtt_pub_hdr;
 
 typedef struct mqtt_fixed_hdr_t {

--- a/src/mqtt/mqtt_codec.c
+++ b/src/mqtt/mqtt_codec.c
@@ -114,7 +114,7 @@ nni_mqtt_msg_decode(nni_msg *msg)
 {
 	int ret;
 	if ((ret = nni_mqtt_msg_decode_fixed_header(msg)) != MQTT_SUCCESS) {
-		nni_plat_printf("decode_fixed_header failed %d\n", ret);
+		// nni_plat_printf("decode_fixed_header failed %d\n", ret);
 		return ret;
 	}
 	nni_mqtt_proto_data *mqtt = nni_msg_get_proto_data(msg);
@@ -814,9 +814,7 @@ nni_mqtt_msg_decode_fixed_header(nni_msg *msg)
 		return MQTT_ERR_PROTOCOL;
 	}
 
-	uint8_t first = (uint8_t)(*header);
-
-	memcpy(&mqtt->fixed_header.common, &first, 1);
+	memcpy(&mqtt->fixed_header.common, header, 1);
 
 	uint8_t  used_bytes;
 	uint32_t remain_len = 0;

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -41,7 +41,7 @@ test_dup(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_SUBSCRIBE);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBSCRIBE);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBSCRIBE);
 
 	nng_mqtt_topic_qos topic_qos[] = {
 		{ .qos     = 0,
@@ -62,10 +62,10 @@ test_dup(void)
 	print_mqtt_msg(msg);
 	print_mqtt_msg(msg2);
 
-	NUTS_ASSERT(memcmp(nng_msg_header(msg), nng_msg_header(msg2),
+	NUTS_TRUE(memcmp(nng_msg_header(msg), nng_msg_header(msg2),
 	                nng_msg_header_len(msg)) == 0);
 
-	NUTS_ASSERT(memcmp(nng_msg_body(msg), nng_msg_body(msg2),
+	NUTS_TRUE(memcmp(nng_msg_body(msg), nng_msg_body(msg2),
 	                nng_msg_len(msg)) == 0);
 
 	nng_msg_free(msg);
@@ -81,11 +81,11 @@ test_encode_connect(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_CONNECT);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_CONNECT);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_CONNECT);
 
 	nng_mqtt_msg_set_connect_client_id(msg, client_id);
 
-	NUTS_ASSERT(strncmp(nng_mqtt_msg_get_connect_client_id(msg),
+	NUTS_TRUE(strncmp(nng_mqtt_msg_get_connect_client_id(msg),
 	                client_id, strlen(client_id)) == 0);
 
 	char will_topic[] = "/nanomq/will_msg";
@@ -112,7 +112,7 @@ test_encode_connect(void)
 	NUTS_PASS(nng_mqtt_msg_decode(decode_msg));
 	print_mqtt_msg(decode_msg);
 
-	// NUTS_ASSERT(memcmp(nng_msg_body(msg), nng_msg_body(decode_msg),
+	// NUTS_TRUE(memcmp(nng_msg_body(msg), nng_msg_body(decode_msg),
 	//                 nng_msg_len(msg)) == 0);
 
 	nng_msg_free(decode_msg);
@@ -126,7 +126,7 @@ test_encode_connack(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_CONNACK);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_CONNACK);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_CONNACK);
 
 	nng_mqtt_msg_set_connack_flags(msg, 1);
 
@@ -146,7 +146,7 @@ test_encode_publish(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_PUBLISH);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_PUBLISH);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_PUBLISH);
 
 	nng_mqtt_msg_set_publish_qos(msg, 2);
 	nng_mqtt_msg_set_publish_retain(msg, true);
@@ -173,7 +173,7 @@ test_encode_puback(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_PUBACK);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_PUBACK);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_PUBACK);
 
 	NUTS_PASS(nng_mqtt_msg_encode(msg));
 
@@ -189,7 +189,7 @@ test_encode_subscribe(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_SUBSCRIBE);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBSCRIBE);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBSCRIBE);
 
 	nng_mqtt_topic_qos topic_qos[] = {
 		{ .qos     = 0,
@@ -217,7 +217,7 @@ test_encode_suback(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_SUBACK);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBACK);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_SUBACK);
 
 	uint8_t ret_codes[] = { 0, 1, 2, 3 };
 
@@ -238,7 +238,7 @@ test_encode_unsubscribe(void)
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
 	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_UNSUBSCRIBE);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_UNSUBSCRIBE);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_UNSUBSCRIBE);
 
 	nng_mqtt_topic topic_qos[] = {
 		{ .buf      = (uint8_t *) "/nanomq/mqtt/1",
@@ -262,8 +262,8 @@ test_encode_disconnect(void)
 
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
-	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_UNSUBSCRIBE);
-	NUTS_ASSERT(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_UNSUBSCRIBE);
+	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_DISCONNECT);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_DISCONNECT);
 	NUTS_PASS(nng_mqtt_msg_encode(msg));
 
 	print_mqtt_msg(msg);

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -63,10 +63,42 @@ test_dup(void)
 	print_mqtt_msg(msg2);
 
 	NUTS_TRUE(memcmp(nng_msg_header(msg), nng_msg_header(msg2),
-	                nng_msg_header_len(msg)) == 0);
+	              nng_msg_header_len(msg)) == 0);
 
 	NUTS_TRUE(memcmp(nng_msg_body(msg), nng_msg_body(msg2),
-	                nng_msg_len(msg)) == 0);
+	              nng_msg_len(msg)) == 0);
+
+	nng_msg_free(msg2);
+	nng_msg_free(msg);
+}
+
+void
+test_dup_publish(void)
+{
+	nng_msg *msg;
+
+	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
+
+	nng_mqtt_msg_set_packet_type(msg, NNG_MQTT_PUBLISH);
+	NUTS_TRUE(nng_mqtt_msg_get_packet_type(msg) == NNG_MQTT_PUBLISH);
+
+	nng_mqtt_msg_set_publish_qos(msg, 0);
+	nng_mqtt_msg_set_publish_topic(msg, "/nanomq/msg");
+	nng_mqtt_msg_set_publish_payload(msg, (uint8_t *) "aaaaaaaa", 8);
+
+	// NUTS_PASS(nng_mqtt_msg_encode(msg));
+
+	nng_msg *msg2;
+	NUTS_PASS(nng_msg_dup(&msg2, msg));
+
+	print_mqtt_msg(msg);
+	print_mqtt_msg(msg2);
+
+	NUTS_TRUE(memcmp(nng_msg_header(msg), nng_msg_header(msg2),
+	              nng_msg_header_len(msg)) == 0);
+
+	NUTS_TRUE(memcmp(nng_msg_body(msg), nng_msg_body(msg2),
+	              nng_msg_len(msg)) == 0);
 
 	nng_msg_free(msg);
 	nng_msg_free(msg2);
@@ -76,7 +108,7 @@ void
 test_encode_connect(void)
 {
 	nng_msg *msg;
-	char client_id[] = "nanomq-mqtt";
+	char     client_id[] = "nanomq-mqtt";
 
 	NUTS_PASS(nng_mqtt_msg_alloc(&msg, 0));
 
@@ -85,8 +117,8 @@ test_encode_connect(void)
 
 	nng_mqtt_msg_set_connect_client_id(msg, client_id);
 
-	NUTS_TRUE(strncmp(nng_mqtt_msg_get_connect_client_id(msg),
-	                client_id, strlen(client_id)) == 0);
+	NUTS_TRUE(strncmp(nng_mqtt_msg_get_connect_client_id(msg), client_id,
+	              strlen(client_id)) == 0);
 
 	char will_topic[] = "/nanomq/will_msg";
 	nng_mqtt_msg_set_connect_will_topic(msg, will_topic);
@@ -477,6 +509,7 @@ test_decode_suback(void)
 TEST_LIST = {
 	{ "alloc message", test_alloc },
 	{ "dup message", test_dup },
+	{ "dup publish message", test_dup_publish },
 	{ "encode connect", test_encode_connect },
 	{ "encode conack", test_encode_connack },
 	{ "encode publish", test_encode_publish },

--- a/src/nng.c
+++ b/src/nng.c
@@ -2310,7 +2310,7 @@ nng_mqtt_topic_array_set(
 void
 nng_mqtt_topic_array_free(nng_mqtt_topic *topic, size_t n)
 {
-	return nni_mqtt_topic_array_free(topic, n);
+	nni_mqtt_topic_array_free(topic, n);
 }
 
 nng_mqtt_topic_qos *
@@ -2323,13 +2323,13 @@ void
 nng_mqtt_topic_qos_array_set(nng_mqtt_topic_qos *topic_qos, size_t index,
     const char *topic_name, uint8_t qos)
 {
-	return nni_mqtt_topic_qos_array_set(topic_qos, index, topic_name, qos);
+	nni_mqtt_topic_qos_array_set(topic_qos, index, topic_name, qos);
 }
 
 void
 nng_mqtt_topic_qos_array_free(nng_mqtt_topic_qos *topic_qos, size_t n)
 {
-	return nni_mqtt_topic_qos_array_free(topic_qos, n);
+	nni_mqtt_topic_qos_array_free(topic_qos, n);
 }
 
 void


### PR DESCRIPTION
1.  FIX [mqtt] dup invalid content before encoding;
2. FIX [mqtt_test] run failed on Windows;
