### PR TITLE
Fix mqtt client protocol dead lock when stopping pipe

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -375,12 +375,8 @@ static void
 mqtt_pipe_stop(void *arg)
 {
 	mqtt_pipe_t *p = arg;
-	mqtt_sock_t *s = p->mqtt_sock;
-
-	nni_mtx_lock(&s->mtx);
 	nni_aio_stop(&p->send_aio);
 	nni_aio_stop(&p->recv_aio);
-	nni_mtx_unlock(&s->mtx);
 }
 
 void


### PR DESCRIPTION
  We hold the sock lock when calling nni_aio_stop which will block
  waiting the callbacks to finish, which in turn want to acquire the
  sock lock, thus dead lock happens.